### PR TITLE
add new register() function to establish zope listener via SQLAlchemy events

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,13 @@ Changes
 0.7.4 (unreleased)
 ------------------
 
+* Add a new function zope.sqlalchemy.register(), which replaces the
+  direct use of ZopeTransactionExtension to make use
+  of the newer SQLAlchemy event system to establish instrumentation on
+  the given Session instance/class/factory.   Requires at least
+  SQLAlchemy 0.7.
+
+
 0.7.3 (2013-09-25)
 ------------------
 
@@ -56,7 +63,7 @@ Changes
 ----------------
 
 * Remove redundant session.flush() / session.clear() on savepoint operations.
-  These were only needed with SQLAlchemy 0.4.x. 
+  These were only needed with SQLAlchemy 0.4.x.
 
 * SQLAlchemy 0.6.x support. Require SQLAlchemy >= 0.5.1.
 
@@ -101,7 +108,7 @@ Bugs fixed:
 
 Feature changes:
 
-* For correctness and consistency with ZODB, renamed the function 'invalidate' 
+* For correctness and consistency with ZODB, renamed the function 'invalidate'
   to 'mark_changed' and the status 'invalidated' to 'changed'.
 
 0.2 (2008-06-28)

--- a/src/zope/sqlalchemy/README.txt
+++ b/src/zope/sqlalchemy/README.txt
@@ -83,7 +83,7 @@ Now to define the mapper classes.
     ...     email = Column('email', String(50))
     ...     user_id = Column('user_id', Integer, ForeignKey('test_users.id'))
 
-Create an engine and setup the tables. Note that for this example to work a 
+Create an engine and setup the tables. Note that for this example to work a
 recent version of sqlite/pysqlite is required. 3.4.0 seems to be sufficient.
 
     >>> engine = create_engine(TEST_DSN, convert_unicode=True)
@@ -207,6 +207,24 @@ transaction extension:
 The session must then be closed manually:
 
     >>> session.close()
+
+Registration Using SQLAlchemy Events
+====================================
+
+The zope.sqlalchemy.register() function performs the same function as the
+ZopeTransactionExtension, except makes use of the newer SQLAlchemy event system
+which superseded the extension system as of SQLAlchemy 0.7.   Usage is similar:
+
+    >>> from zope.sqlalchemy import register
+    >>> Session = scoped_session(sessionmaker(bind=engine,
+    ... twophase=TEST_TWOPHASE))
+    >>> register(Session, keep_session=True)
+    >>> session = Session()
+    >>> jack = User(id=2, name='jack')
+    >>> session.add(jack)
+    >>> transaction.commit()
+    >>> engine.execute("select name from test_users where id=2").scalar()
+    u'jack'
 
 
 Development version

--- a/src/zope/sqlalchemy/__init__.py
+++ b/src/zope/sqlalchemy/__init__.py
@@ -14,5 +14,5 @@
 
 __version__ = '0.7.4dev'
 
-from zope.sqlalchemy.datamanager import ZopeTransactionExtension, mark_changed
+from zope.sqlalchemy.datamanager import ZopeTransactionExtension, mark_changed, register
 invalidate = mark_changed


### PR DESCRIPTION
this pullreq makes available a register() function which connects a ZopeTransactionExtension instance to a target Session class, factory or instance via direct use of the SQLAlchemy event API available as of SQLAlchemy 0.7.  While SQLAlchemy's SessionExtension is remaining indefinitely, this calling style is the more up-to-date style and also allows for more flexibility as far as the event target, including ad-hoc registration (and de-registration in 0.9) of specific events.
