### PR TITLE
Fix the tests by using an older transaction version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
+*.egg-info
+*.pyc
+.eggs/
 .installed.cfg
 .tox/
-*.pyc
-*.egg-info
 bin/
 develop-eggs/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
 before_install:
   - CONFIG_FILE=$(sudo -u postgres psql postgres -c "SHOW config_file;" -q -t | head -1)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Changes
 
 - Drop support for Python 2.6 and 3.2.
 
+- *Attention:* This versions currently does not support ``transaction >= 1.5``. (See https://github.com/zopefoundation/zope.sqlalchemy/issues/20)
+
 
 0.7.7 (2016-06-23)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 Changes
 =======
 
-0.7.8 (unreleased)
-------------------
+1.0 (unreleased)
+----------------
 
-- Nothing changed yet.
+- Drop support for Python 2.6 and 3.2.
 
 
 0.7.7 (2016-06-23)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
       'setuptools',
       'SQLAlchemy>=0.5.1',
-      'transaction',
+      'transaction < 1.5',
       'zope.interface>=3.6.0',
       ],
     extras_require={'test': tests_require},

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ tests_require = ['zope.testing']
 
 setup(
     name='zope.sqlalchemy',
-    version='0.7.8.dev0',
+    version='1.0.dev0',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
@@ -25,10 +25,8 @@ setup(
     "Framework :: Zope3",
     "Programming Language :: Python",
     "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.6",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.2",
     "Programming Language :: Python :: 3.3",
     "License :: OSI Approved :: Zope Public License",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py26,py27,py32,py33
+    py27,
+    py33,
 # pypy fails because of some weird test error that might be an issue with
 # sqlalchemy, pypy, and issues with object identity.
 


### PR DESCRIPTION
The last time the tests were green was running with transaction 1.4.4.
So pin the to this version for now.