### PR TITLE
Use a WeakKeyDictionary to store session => status map

### DIFF
--- a/src/zope/sqlalchemy/README.txt
+++ b/src/zope/sqlalchemy/README.txt
@@ -188,7 +188,7 @@ after a commit. You can tell by trying to access an object after committing:
     >>> transaction.commit()
     >>> bob.name
     Traceback (most recent call last):
-    DetachedInstanceError: Instance <User at ...> is not bound to a Session; attribute refresh operation cannot proceed
+    DetachedInstanceError: Instance <User at ...> is not bound to a Session; attribute refresh operation cannot proceed...
 
 To support cases where a session needs to last longer than a transaction
 (useful in test suites) you can specify to keep a session when creating the

--- a/src/zope/sqlalchemy/tests.py
+++ b/src/zope/sqlalchemy/tests.py
@@ -245,7 +245,7 @@ class ZopeSQLAlchemyTests(unittest.TestCase):
         dummy = DummyDataManager(key='dummy.first')
         session = Session()
         mark_changed(session)
-        self.assertTrue(id(session) in zope.sqlalchemy.datamanager._SESSION_STATE)
+        self.assertTrue(session in zope.sqlalchemy.datamanager._SESSION_STATE)
 
     def testAbortBeforeCommit(self):
         # Simulate what happens in a conflict error


### PR DESCRIPTION
We encountered [an issue in our app](https://github.com/hypothesis/h/issues/4704) which uses Pyramid + pyramid_tm + zope.sqlalchemy where requests would occasionally complete successfully yet the DB changes from that request did not get committed.

It turned out that what was happening is that sometimes our logging code caused accesses to the DB session after the transaction commit/abort performed by pyramid_tm, and these DB accesses caused stale entries (IDs of now-dead Session objects) to be left in zope.sqlalchemy's internal `_SESSION_STATE` cache after request processing ended.

These stale entries caused future Sessions which happened to share the same ID (because they happened to be allocated at the same address in memory by the CPython runtime), not to be committed.

Although this issue ultimately boils down to a programming error in our app, it took a lot of time to debug and I can imagine other users getting caught out. This PR removes the hazard by replacing the `id(session)` map with a `WeakKeyDictionary` so that Python automatically removes entries to dead sessions from the map.