### PR TITLE
Support transaction>=1.6.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Changes
 
 - Add support for Python 3.4 up to 3.6.
 
+- Drop support for transaction < 1.6.0.
+
 
 0.7.7 (2016-06-23)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,8 +8,6 @@ Changes
 
 - Add support for Python 3.4 up to 3.6.
 
-- Require transaction >= 1.6.0.
-
 
 0.7.7 (2016-06-23)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ Changes
 
 - Add support for Python 3.4 up to 3.6.
 
-- *Attention:* This versions currently does not support ``transaction >= 1.5``. (See https://github.com/zopefoundation/zope.sqlalchemy/issues/20)
+- Require transaction >= 1.6.0.
 
 
 0.7.7 (2016-06-23)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'setuptools',
         'SQLAlchemy>=0.5.1',
-        'transaction < 1.5',
+        'transaction>=1.6.0',
         'zope.interface>=3.6.0',
     ],
     extras_require={'test': tests_require},

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'setuptools',
         'SQLAlchemy>=0.5.1',
-        'transaction',
+        'transaction>=1.6.0',
         'zope.interface>=3.6.0',
     ],
     extras_require={'test': tests_require},

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         'setuptools',
         'SQLAlchemy>=0.5.1',
-        'transaction>=1.6.0',
+        'transaction',
         'zope.interface>=3.6.0',
     ],
     extras_require={'test': tests_require},

--- a/src/zope/sqlalchemy/tests.py
+++ b/src/zope/sqlalchemy/tests.py
@@ -43,7 +43,6 @@ def b(s):
         return s
 
 import os
-import pkg_resources
 import re
 import unittest
 import transaction
@@ -153,8 +152,6 @@ bound_metadata2 = sa.MetaData(engine2)
 
 test_one = sa.Table('test_one', bound_metadata1, sa.Column('id', sa.Integer, primary_key=True))
 test_two = sa.Table('test_two', bound_metadata2, sa.Column('id', sa.Integer, primary_key=True))
-
-transaction_version = pkg_resources.get_distribution('transaction').parsed_version
 
 
 class TestOne(SimpleModel):
@@ -340,17 +337,6 @@ class ZopeSQLAlchemyTests(unittest.TestCase):
         self.assertTrue(
             [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
             "Not joined transaction")
-        transaction.abort()
-        conn = Session().connection()
-        if transaction_version < pkg_resources.parse_version('1.6.0'):
-            self.assertTrue(
-                [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
-                "Not joined transaction")
-        else:
-            self.assertEqual(
-                [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
-                [],
-                "Not joined transaction")
 
     def testTransactionJoiningUsingRegister(self):
         transaction.abort()  # clean slate
@@ -364,17 +350,6 @@ class ZopeSQLAlchemyTests(unittest.TestCase):
         self.assertTrue(
             [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
             "Not joined transaction")
-        transaction.abort()
-        conn = EventSession().connection()
-        if transaction_version < pkg_resources.parse_version('1.6.0'):
-            self.assertTrue(
-                [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
-                "Not joined transaction")
-        else:
-            self.assertEqual(
-                [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
-                [],
-                "Not joined transaction")
 
     def testSavepoint(self):
         use_savepoint = not engine.url.drivername in tx.NO_SAVEPOINT_SUPPORT

--- a/src/zope/sqlalchemy/tests.py
+++ b/src/zope/sqlalchemy/tests.py
@@ -339,8 +339,9 @@ class ZopeSQLAlchemyTests(unittest.TestCase):
             "Not joined transaction")
         transaction.abort()
         conn = Session().connection()
-        self.assertTrue(
+        self.assertEqual(
             [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
+            [],
             "Not joined transaction")
 
     def testTransactionJoiningUsingRegister(self):
@@ -357,8 +358,9 @@ class ZopeSQLAlchemyTests(unittest.TestCase):
             "Not joined transaction")
         transaction.abort()
         conn = EventSession().connection()
-        self.assertTrue(
+        self.assertEqual(
             [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
+            [],
             "Not joined transaction")
 
     def testSavepoint(self):

--- a/src/zope/sqlalchemy/tests.py
+++ b/src/zope/sqlalchemy/tests.py
@@ -43,6 +43,7 @@ def b(s):
         return s
 
 import os
+import pkg_resources
 import re
 import unittest
 import transaction
@@ -152,6 +153,8 @@ bound_metadata2 = sa.MetaData(engine2)
 
 test_one = sa.Table('test_one', bound_metadata1, sa.Column('id', sa.Integer, primary_key=True))
 test_two = sa.Table('test_two', bound_metadata2, sa.Column('id', sa.Integer, primary_key=True))
+
+transaction_version = pkg_resources.get_distribution('transaction').parsed_version
 
 
 class TestOne(SimpleModel):
@@ -339,10 +342,15 @@ class ZopeSQLAlchemyTests(unittest.TestCase):
             "Not joined transaction")
         transaction.abort()
         conn = Session().connection()
-        self.assertEqual(
-            [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
-            [],
-            "Not joined transaction")
+        if transaction_version < pkg_resources.parse_version('1.6.0'):
+            self.assertTrue(
+                [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
+                "Not joined transaction")
+        else:
+            self.assertEqual(
+                [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
+                [],
+                "Not joined transaction")
 
     def testTransactionJoiningUsingRegister(self):
         transaction.abort()  # clean slate
@@ -358,10 +366,15 @@ class ZopeSQLAlchemyTests(unittest.TestCase):
             "Not joined transaction")
         transaction.abort()
         conn = EventSession().connection()
-        self.assertEqual(
-            [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
-            [],
-            "Not joined transaction")
+        if transaction_version < pkg_resources.parse_version('1.6.0'):
+            self.assertTrue(
+                [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
+                "Not joined transaction")
+        else:
+            self.assertEqual(
+                [r for r in t._resources if isinstance(r, tx.SessionDataManager)],
+                [],
+                "Not joined transaction")
 
     def testSavepoint(self):
         use_savepoint = not engine.url.drivername in tx.NO_SAVEPOINT_SUPPORT


### PR DESCRIPTION
Starting from transaction 1.6.0 (see https://github.com/zopefoundation/transaction/commit/2eb00f903002cd170ea66c89856c95b6df4e8066 commit) references to data managers are dropped when transaction committed or aborted.