### PR TITLE
Drop support for Python 3.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 1.0 (unreleased)
 ----------------
 
-- Drop support for Python 2.6 and 3.2.
+- Drop support for Python 2.6, 3.2 and 3.3.
 
 - Add support for Python 3.4 up to 3.6.
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,6 +1,1 @@
-# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)

--- a/src/zope/sqlalchemy/tests.py
+++ b/src/zope/sqlalchemy/tests.py
@@ -24,30 +24,12 @@
 # NOTE: The sqlite that ships with Mac OS X 10.4 is buggy. Install a newer version (3.5.6)
 #       and rebuild pysqlite2 against it.
 
-import sys
-
-PY3 = sys.version_info[0] == 3
-
-
-def u(s):
-    if PY3:
-        return s
-    else:
-        return s.decode('utf-8')
-
-
-def b(s):
-    if PY3:
-        return s.encode('utf-8')
-    else:
-        return s
-
 import os
 import re
-import unittest
-import transaction
 import threading
 import time
+import transaction
+import unittest
 
 from transaction._transaction import Status as ZopeStatus
 from transaction.interfaces import TransactionFailedError
@@ -710,7 +692,7 @@ class RetryTests(unittest.TestCase):
         self.assertTrue(len(s2.query(User).all()) == 1, "Users table should have one row")
         s1.query(User).delete()
         user = s2.query(User).get(1)
-        user.lastname = u('smith')
+        user.lastname = u'smith'
         tm1.commit()
         raised = False
         try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py27,
-    py33,
     py34,
     py35,
     py36,


### PR DESCRIPTION
Additionally clean up Python 3.2 remainders.