### PR TITLE
Restore possibility to change keep_session param.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changes
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+* ``.datamanager.register()`` now returns the ``ZopeTransactionEvents``
+  instance which was used to register the events. This allows to change its
+  parameters afterwards.
+  (`#40 <https://github.com/zopefoundation/zope.sqlalchemy/pull/40>`_)
 
 
 1.2 (2019-10-17)

--- a/src/zope/sqlalchemy/README.rst
+++ b/src/zope/sqlalchemy/README.rst
@@ -102,6 +102,7 @@ same session. At present there are no users in the database.
 
     >>> session = Session()
     >>> register(session)
+    <zope.sqlalchemy.datamanager.ZopeTransactionEvents object at ...>
     >>> session.query(User).all()
     []
 
@@ -169,6 +170,7 @@ session in the 'changed' state initially.
 
     >>> Session.remove()
     >>> register(Session, 'changed')
+    <zope.sqlalchemy.datamanager.ZopeTransactionEvents object at ...>
     >>> session = Session()
     >>> conn = session.connection()
     >>> conn.execute(users.update(users.c.name=='ben'), name='bob')
@@ -197,6 +199,7 @@ in test suites) you can specify to keep a session when registering the events:
     >>> Session = scoped_session(sessionmaker(bind=engine,
     ... twophase=TEST_TWOPHASE))
     >>> register(Session, keep_session=True)
+    <zope.sqlalchemy.datamanager.ZopeTransactionEvents object at ...>
     >>> session = Session()
     >>> bob = session.query(User).all()[0]
     >>> bob.name = 'bobby'

--- a/src/zope/sqlalchemy/datamanager.py
+++ b/src/zope/sqlalchemy/datamanager.py
@@ -323,3 +323,4 @@ def register(
     event.listen(session, "after_bulk_update", ext.after_bulk_update)
     event.listen(session, "after_bulk_delete", ext.after_bulk_delete)
     event.listen(session, "before_commit", ext.before_commit)
+    return ext

--- a/src/zope/sqlalchemy/datamanager.py
+++ b/src/zope/sqlalchemy/datamanager.py
@@ -308,6 +308,9 @@ def register(
     Event listening will be specific to the scope of the type of argument
     passed, including specificity to its subclass as well as its identity.
 
+    It returns the instance of ZopeTransactionEvents those methods where used
+    to register the event listeners.
+
     """
     from sqlalchemy import event
 


### PR DESCRIPTION
Before version 1.2 it was possible to change the value of `keep_session` for certain tests.
We used `keep_session=True` to ease unittests which are not forced to re-fetch objects from database after a commit. On the other hand selenium tests should behave more like an actual web server which does not keep the session.
So we switched to `keep_session=False` for some tests with code like this:
https://github.com/gocept/risclog.sqlalchemy/blob/44fe2494337b41e0bc3d5602ebbd7493918d841d/src/risclog/sqlalchemy/fixtures.py#L6

This is no longer possible since zope.sqlalchemy 1.2.
With this commit the ability to access the `ZopeTransactionEvents` instance is restored.