### PR TITLE
Fix string comparison (use != instead of is not)

### DIFF
--- a/src/zope/sqlalchemy/datamanager.py
+++ b/src/zope/sqlalchemy/datamanager.py
@@ -129,7 +129,7 @@ class SessionDataManager(object):
         pass
 
     def tpc_abort(self, trans):
-        assert self.state is not "committed"
+        assert self.state != "committed"
 
     def sortKey(self):
         # Try to sort last, so that we vote last - we may commit in tpc_vote(),


### PR DESCRIPTION
Python 3.8 gives a warning for us in `zope/sqlalchemy/datamanager.py:132`:

`SyntaxWarning: "is not" with a literal. Did you mean "!="`?

That warning seems correct, and the `is not` might even lead to unintended results. So this line should probably be changed to `!=` .