### PR TITLE
idea for mark_changed api improvement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changes
 
 - Drop support for Python 3.5.
 
+- Add ``mark_changed`` and ``join_transaction`` methods to
+  ``ZopeTransactionEvents``.
+  (`#46 <https://github.com/zopefoundation/zope.sqlalchemy/issues/46>`_)
+
 
 1.3 (2020-02-17)
 ----------------

--- a/src/zope/sqlalchemy/README.rst
+++ b/src/zope/sqlalchemy/README.rst
@@ -223,10 +223,10 @@ If you intend for `keep_session` to be True, you can specify it explicitly:
     >>> mark_changed(session, keep_session=True)
     >>> transaction.commit()
 
-You can also use the configured extension to preserve this argument
+You can also use a configured extension to preserve this argument:
 
-    >>> sessionExtension = register(Session, keep_session=True)
-    >>> sessionExtension.mark_changed()
+    >>> sessionExtension = register(session, keep_session=True)
+    >>> sessionExtension.mark_changed(session)
 
 
 Long-lasting session scopes

--- a/src/zope/sqlalchemy/README.rst
+++ b/src/zope/sqlalchemy/README.rst
@@ -213,6 +213,22 @@ session in the 'changed' state initially.
     'bob'
     >>> transaction.abort()
 
+The `mark_changed` function accepts a kwarg for `keep_session` which defaults
+to `False` and is unaware of the registered extensions `keep_session`
+configuration.
+
+If you intend for `keep_session` to be True, you can specify it explicitly:
+
+    >>> from zope.sqlalchemy import mark_changed
+    >>> mark_changed(session, keep_session=True)
+    >>> transaction.commit()
+
+You can also use the configured extension to preserve this argument
+
+    >>> sessionExtension = register(Session, keep_session=True)
+    >>> sessionExtension.mark_changed()
+
+
 Long-lasting session scopes
 ---------------------------
 

--- a/src/zope/sqlalchemy/README.rst
+++ b/src/zope/sqlalchemy/README.rst
@@ -227,6 +227,7 @@ You can also use a configured extension to preserve this argument:
 
     >>> sessionExtension = register(session, keep_session=True)
     >>> sessionExtension.mark_changed(session)
+    >>> transaction.commit()
 
 
 Long-lasting session scopes

--- a/src/zope/sqlalchemy/datamanager.py
+++ b/src/zope/sqlalchemy/datamanager.py
@@ -289,6 +289,19 @@ class ZopeTransactionEvents(object):
             or self.transaction_manager.get().status == ZopeStatus.COMMITTING
         ), "Transaction must be committed using the transaction manager"
 
+    def mark_changed(self, session):
+        """Developer interface to `mark_changed` that preserves the extension's
+        active configuration.
+        """
+        mark_changed(session, self.transaction_manager, self.keep_session)
+
+    def join_transaction(self, session):
+        """Developer interface to `join_transaction` that preserves the
+        extension's active configuration.
+        """
+        join_transaction(
+            session, self.initial_state, self.transaction_manager, self.keep_session
+        )
 
 def register(
     session,


### PR DESCRIPTION
fixes #46 

it doesn't include tests.  the `register(` system doesn't seem to have tests, so I didn't have anything to base it off of.