### PR TITLE
Do not use signature deprecated since SQLAlchemy 0.9.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Changes
   ``ZopeTransactionEvents``.
   (`#46 <https://github.com/zopefoundation/zope.sqlalchemy/issues/46>`_)
 
-- Reduce DeprecationWarnings with SQLAlchemy 1.4.
+- Reduce DeprecationWarnings with SQLAlchemy 1.4 and require at least
+  SQLAlchemy >= 0.9.
   (`#54 <https://github.com/zopefoundation/zope.sqlalchemy/issues/54>`_)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes
   ``ZopeTransactionEvents``.
   (`#46 <https://github.com/zopefoundation/zope.sqlalchemy/issues/46>`_)
 
-- Reduce ``DeprecationWarning``s with SQLAlchemy 1.4.
+- Reduce DeprecationWarnings with SQLAlchemy 1.4.
   (`#54 <https://github.com/zopefoundation/zope.sqlalchemy/issues/54>`_)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changes
   ``ZopeTransactionEvents``.
   (`#46 <https://github.com/zopefoundation/zope.sqlalchemy/issues/46>`_)
 
+- Reduce ``DeprecationWarning``s with SQLAlchemy 1.4.
+  (`#54 <https://github.com/zopefoundation/zope.sqlalchemy/issues/54>`_)
+
 
 1.3 (2020-02-17)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
 
     install_requires=[
         'setuptools',
-        'SQLAlchemy>=0.7',
+        'SQLAlchemy>=0.9',
         'transaction>=1.6.0',
         'zope.interface>=3.6.0',
     ],

--- a/src/zope/sqlalchemy/datamanager.py
+++ b/src/zope/sqlalchemy/datamanager.py
@@ -291,11 +291,13 @@ class ZopeTransactionEvents(object):
     def after_flush(self, session, flush_context):
         mark_changed(session, self.transaction_manager, self.keep_session)
 
-    def after_bulk_update(self, session, query, query_context, result):
-        mark_changed(session, self.transaction_manager, self.keep_session)
+    def after_bulk_update(self, update_context):
+        mark_changed(update_context.session,
+                     self.transaction_manager, self.keep_session)
 
-    def after_bulk_delete(self, session, query, query_context, result):
-        mark_changed(session, self.transaction_manager, self.keep_session)
+    def after_bulk_delete(self, delete_context):
+        mark_changed(delete_context.session,
+                     self.transaction_manager, self.keep_session)
 
     def before_commit(self, session):
         assert (


### PR DESCRIPTION
This does not introduce complete compatibility of this package with SQLAlchemy but avoids some deprecation warnings. 

Fixes #54.