### PR TITLE
add multiple version sqlalchemy testing in tox config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         config:
         # [Python version, tox env]
@@ -53,9 +54,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install tox tox-factor
     - name: Test
-      run: tox -e ${{ matrix.config[1] }}
+      run: tox -f ${{ matrix.config[1] }}
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,8 @@
 minversion = 3.18
 envlist =
     lint
-    py27
-    py35
-    py36
-    py37
-    py38
-    py39
+    py{27,35,36}-sqlalchemy{09,10}
+    py{27,35,36,37,38,39}-sqlalchemy{11,12,13}
     coverage
 
 [testenv]
@@ -18,6 +14,12 @@ skip_install = true
 deps =
     setuptools < 52
     zc.buildout
+    sqlalchemy09: SQLAlchemy==0.9
+    sqlalchemy10: SQLAlchemy==1.0
+    sqlalchemy11: SQLAlchemy==1.1
+    sqlalchemy12: SQLAlchemy==1.2
+    sqlalchemy13: SQLAlchemy==1.3
+    sqlalchemy14: SQLAlchemy==1.4
 commands_pre =
     sh -c 'if [ '{env:CI:false}' = 'true' ]; then {envbindir}/buildout -nc {toxinidir}/github_actions.cfg buildout:directory={envdir} buildout:develop={toxinidir} ; fi'
     sh -c 'if [ '{env:CI:false}' != 'true' ]; then {envbindir}/buildout -nc {toxinidir}/postgres.cfg buildout:directory={envdir} buildout:develop={toxinidir} ; fi'
@@ -70,6 +72,7 @@ allowlist_externals =
     mkdir
 deps =
     {[testenv]deps}
+    SQLAlchemy==1.3
     coverage
     coverage-python-version
 commands =


### PR DESCRIPTION
As a wide range of SQLAlchemy versions is supported, and in preparation of breaking changes in SQLAlchemy 1.4/2.0, I thought it would be a good idea to test exactly whcih versions are supported now. It turns out that tests pass for sqlalchemy 0.9 - 1.3 (depending slightly on the python version, 0.9 and 1.0 are only supported for python <=3.6)

I'll work on supporting SQLAlchemy 1.4 in a separate PR and try to address the issues raised in #54, #57, #58 and #60. But this is at least a nice baseline. 

PS: The setup.py claims minimum supported SQLAlchemy version is 0.7, but the tests break on 0.7
