### PR TITLE
Fix SQLAlchemy 2.0 deprecation warnings

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -37,6 +37,9 @@ testenv-commands = [
     "sh -c 'if [ '{env:CI:false}' = 'true' ]; then {envbindir}/testpg {posargs:-cv} ; fi'",
     "sh -c 'if [ '{env:CI:false}' = 'true' ]; then {envbindir}/testpg2 {posargs:-cv} ; fi'",
     ]
+testenv-setenv = [
+    "SQLALCHEMY_WARN_20 = true",
+    ]
 testenv-additional = [
     "passenv =",
     "    CI",

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ deps =
     sqlalchemy12: SQLAlchemy==1.2.*
     sqlalchemy13: SQLAlchemy==1.3.*
     sqlalchemy14: SQLAlchemy==1.4.*
+setenv =
+    SQLALCHEMY_WARN_20 = true
 commands_pre =
     sh -c 'if [ '{env:CI:false}' = 'true' ]; then {envbindir}/buildout -nc {toxinidir}/github_actions.cfg buildout:directory={envdir} buildout:develop={toxinidir} ; fi'
     sh -c 'if [ '{env:CI:false}' != 'true' ]; then {envbindir}/buildout -nc {toxinidir}/postgres.cfg buildout:directory={envdir} buildout:develop={toxinidir} ; fi'


### PR DESCRIPTION
There are the following warnings raised in the test code. To be fully compatible with 2.0, at least this list of warnings will need to be addressed:

- [ ] `MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base()`
- [ ] `RemovedIn20Warning: Passing a string to Connection.execute() is deprecated and will be removed in version 2.0.  Use the text() construct, or the Connection.exec_driver_sql() method to invoke a driver-level SQL string`
- [ ] `RemovedIn20Warning: The ``bind`` argument for schema methods that invoke SQL against an engine or connection will be required in SQLAlchemy 2.0`
- [ ] `RemovedIn20Warning: The connection.execute() method in SQLAlchemy 2.0 will accept parameters as a single dictionary or a single sequence of dictionaries only. Parameters passed as keyword arguments, tuples or positionally oriened dictionaries and/or tuples will no longer be accepted.`
- [ ] `RemovedIn20Warning: The FromClause.select().whereclause parameter is deprecated and will be removed in version 2.0.  Please make use of the Select.where() method to add WHERE criteria to the SELECT statement`
- [ ] `RemovedIn20Warning: The legacy calling style of select() is deprecated and will be removed in SQLAlchemy 2.0.  Please use the new calling style described at select()`
- [ ] `RemovedIn20Warning: The Query.get() method is considered legacy as of the 1.x series of SQLAlchemy and becomes a legacy construct in 2.0. The method is now available as Session.get()`
- [ ] `RemovedIn20Warning: The relation construct is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. Please use relationship()`
- [ ] `RemovedIn20Warning: The Session.transaction attribute is considered legacy as of the 1.x series of SQLAlchemy and will be removed in 2.0. For context manager use, use Session.begin().  To access the current root transaction, use Session.get_transaction()`
- [ ] `RemovedIn20Warning: The update.whereclause parameter will be removed in SQLAlchemy 2.0.  Please refer to the Update.where() method.`
- [ ] `RemovedIn20Warning: This Session located a target engine via bound metadata; as this functionality will be removed in SQLAlchemy 2.0, an Engine object should be passed to the Session() constructor directly`
