### PR TITLE
Fix legacy Python versions.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,7 +28,7 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml}]
+[*.{yml,zpt,pt,dtml,zcml}]
 # 2 space indentation
 indent_size = 2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,11 @@ on:
 jobs:
   build:
     strategy:
-      # We want do see all failures:
+      # We want to see all failures:
       fail-fast: false
       matrix:
+        os:
+        - ubuntu
         config:
         # [Python version, tox env]
         - ["3.8",   "lint"]
@@ -27,7 +29,7 @@ jobs:
         - ["3.9",   "py39"]
         - ["3.8",   "coverage"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     name: ${{ matrix.config[1] }}
     steps:
     - name: "Configure PostgreSQL"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.profraw
 *.pyc
 *.pyo
+*.so
 .coverage
 .coverage.*
 .eggs/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,14 +2,14 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "9f90556c794c07fb953906696fc3037b2847239d"
+commit-id = "7f4327fd1d2df77214735d6ed9a1d4687ff28f6f"
 
 [python]
-with-appveyor = false
 with-pypy = false
 with-legacy-python = true
-with-docs = false
 with-sphinx-doctests = false
+with-windows = false
+with-future-python = false
 
 [coverage]
 fail-under = 70
@@ -21,6 +21,8 @@ additional-envlist = [
     "py{36,37,38,39}-sqlalchemy{14}",
     ]
 testenv-deps = [
+    "py27: psycopg2 < 2.9",
+    "py35: psycopg2 < 2.9",
     "sqlalchemy09: SQLAlchemy==0.9.*",
     "sqlalchemy10: SQLAlchemy==1.0.*",
     "sqlalchemy11: SQLAlchemy==1.1.*",

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ skip_install = true
 deps =
     setuptools < 52
     zc.buildout
+    py27: psycopg2 < 2.9
+    py35: psycopg2 < 2.9
     sqlalchemy09: SQLAlchemy==0.9.*
     sqlalchemy10: SQLAlchemy==1.0.*
     sqlalchemy11: SQLAlchemy==1.1.*
@@ -89,7 +91,7 @@ commands =
 [coverage:run]
 branch = True
 plugins = coverage_python_version
-source = src
+source = zope.sqlalchemy
 
 [coverage:report]
 precision = 2


### PR DESCRIPTION
We use a version of `zc.buildout` which does not understand `python_requires`.
So we have to do it manually.

Fixes #69.