### PR TITLE
Fix `psycopg.errors.OperationalError.sqlstate` can be `None`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 3.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix ``psycopg.errors.OperationalError.sqlstate`` can be ``None``.
+  (`#81 https://github.com/zopefoundation/zope.sqlalchemy/issues/81`_)
 
 
 3.0 (2023-06-01)

--- a/src/zope/sqlalchemy/datamanager.py
+++ b/src/zope/sqlalchemy/datamanager.py
@@ -45,7 +45,7 @@ except ImportError:
 else:
     _retryable_errors.append(
         (psycopg.errors.OperationalError,
-         lambda e: e.sqlstate.startswith('40'))
+         lambda e: e.sqlstate and e.sqlstate.startswith('40'))
     )
 
 # ORA-08177: can't serialize access for this transaction


### PR DESCRIPTION
Fixes #81.