### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 =======
 
-3.2 (unreleased)
+4.0 (unreleased)
 ----------------
 
 - SQLAlchemy's versions 2.0.32 up to 2.0.35 run into dead locks when running

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 4.0 (unreleased)
 ----------------
 
+* Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - SQLAlchemy's versions 2.0.32 up to 2.0.35 run into dead locks when running
   the tests on Python 3.11+, so excluding them from the list of supported
   versions.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os.path
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -9,11 +8,8 @@ tests_require = ['zope.testing']
 setup(
     name='zope.sqlalchemy',
     version='4.0.dev0',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
-    namespace_packages=['zope'],
     test_suite='zope.sqlalchemy.tests.test_suite',
     author='Laurence Rowe',
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ tests_require = ['zope.testing']
 
 setup(
     name='zope.sqlalchemy',
-    version='3.2.dev0',
+    version='4.0.dev0',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
